### PR TITLE
Update episode index and add stubs for 6 and 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ Episodes generally follow a similar format:
 * [TBS(3): Yet Another Live Stack](episodes/3)
 * [TBS(4): BYO Cluster](episodes/4)
 * [TBS(5): Crossplane v0.4.0](episodes/5)
+* [TBS(6): Crossplane Turns One](episodes/6)
+* [TBS(7): Lost in Translation](episodes/7)
+* [TBS(8): All Things GKE](episodes/8)
+* [TBS(9): Would you like some k3sup on that?](episodes/9)
+* [TBS(10): Local K8s Development with Crossplane + Okteto](episodes/10)
+* [TBS(11): Cluster API](episodes/11)
+* [TBS(12): Linkerd](episodes/12)
+* [TBS(13): OpenFaaS](episodes/13)
 
 ## Requesting a Topic
 

--- a/episodes/6/README.md
+++ b/episodes/6/README.md
@@ -1,0 +1,12 @@
+# TBS[6]: Crossplane Turns One
+
+We are back from Kubecon and celebrating one year of the Crossplane project!
+In this episode of TBS we will take a look at where we started, where we are
+going, and our biggest takeaways from talking with the community at Kubecon.
+For more information, check out this recent blog post by Crossplane founder
+Jared Watts recapping the growth of the ecosystem over the last year:
+<https://blog.crossplane.io/happy-1st-birthday-crossplane/>
+
+Host: [@hasheddan](https://twitter.com/hasheddan)
+
+Live Stream: <https://youtu.be/vfTVfd8anGw>

--- a/episodes/7/README.md
+++ b/episodes/7/README.md
@@ -1,0 +1,12 @@
+# TBS[7]: Lost in Translation
+
+TBS is back and this is going to be a good one! Muvaffak will be joining
+Daniel to talk through how we translate provider APIs into schemas for our
+managed resource CRDs. Muvaffak is the author of the Crossplane Managed
+Resource API Patterns design standard
+<https://github.com/crossplane/crossplane/blob/master/design/one-pager-managed-resource-api-design.md>
+and a core contributor to the Crossplane project!
+
+Hosts: [@hasheddan](https://twitter.com/hasheddan), [@muvaffakonus](https://twitter.com/muvaffakonus)
+
+Live Stream: <https://youtu.be/aVU_NgzgrlI>


### PR DESCRIPTION
* Updates the root index
* adds the youtube summary from episodes 6 and 7 into per episode README.md files

Used `grep '^# ' episodes/*/README.md` to help out.